### PR TITLE
Fix inconsistent grabbing of parent_bid (was mistakenly parent_id)

### DIFF
--- a/lib/faktory_worker/batch.ex
+++ b/lib/faktory_worker/batch.ex
@@ -99,13 +99,13 @@ defmodule FaktoryWorker.Batch do
   def new!(opts \\ []) do
     success = Keyword.get(opts, :on_success)
     complete = Keyword.get(opts, :on_complete)
-    bid = Keyword.get(opts, :parent_id)
+    bid = Keyword.get(opts, :parent_bid)
     description = Keyword.get(opts, :description)
 
     payload =
       %{}
       |> maybe_put_description(description)
-      |> maybe_put_parent_id(bid)
+      |> maybe_put_parent_bid(bid)
       |> maybe_put_callback(:success, success)
       |> maybe_put_callback(:complete, complete)
       |> validate!()
@@ -159,8 +159,8 @@ defmodule FaktoryWorker.Batch do
   defp maybe_put_description(payload, description),
     do: Map.put_new(payload, :description, description)
 
-  defp maybe_put_parent_id(payload, nil), do: payload
-  defp maybe_put_parent_id(payload, bid), do: Map.put_new(payload, :parent_bid, bid)
+  defp maybe_put_parent_bid(payload, nil), do: payload
+  defp maybe_put_parent_bid(payload, bid), do: Map.put_new(payload, :parent_bid, bid)
 
   defp maybe_put_callback(payload, _type, nil), do: payload
 


### PR DESCRIPTION
This is the result of some debugging today that I had to do.

The situation was basically this:

Job A fires off Job B

Job B creates a batch, and passes its big to another module that will
run 4 jobs in their own batches.

The original batch is re-opened to push the new jobs.

We pass the configuration to these new batches to let them know who
their parent is.

In the `Map.put` we put the keyword to `parent_bid`, however in the opts
for the function, we look for `parent_id`.

The reason this came to light is my success callbacks were firing while
longer-running jobs down the chain were still not truly complete.

With this, the API should be consistent. I imagine it was a typo
originally.

I'm happy to add some more precise tests if needed.