### PR TITLE
feat: don't raise on push timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.8.1] - 2022-04-04
+
+- Push timeouts will no longer `raise` by default (instead of raising, they will
+  now return `{:error, :timeout}`).
+
 ## [1.8.0] - 2022-04-04
 - Fix `parent_id` vs `parent_bid`
 This was a typo making passing of children batches require using `parent_id` over `parent_bid` which the docs say
@@ -13,7 +18,7 @@ This was a typo making passing of children batches require using `parent_id` ove
 - Updated exDoc [#151](https://github.com/opt-elixir/faktory_worker/pull/151)
 
 ## [1.6.0] - 2021-11-05
-  
+
 
 ### Added
 

--- a/lib/faktory_worker/connection_manager/server.ex
+++ b/lib/faktory_worker/connection_manager/server.ex
@@ -18,7 +18,9 @@ defmodule FaktoryWorker.ConnectionManager.Server do
           FaktoryWorker.Connection.response()
   def send_command(connection_manager, command, timeout \\ 5000)
 
-  def send_command(connection_manager, {:fetch, _} = command, timeout) do
+  # watch for and catch exits from command that may timeout
+  def send_command(connection_manager, {command_type, _} = command, timeout)
+      when command_type in [:fetch, :push] do
     try do
       GenServer.call(connection_manager, {:send_command, command}, timeout)
     catch

--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -131,6 +131,7 @@ defmodule FaktoryWorker.Job do
         payload.args,
         opts
       )
+
       {:ok, payload}
     else
       opts
@@ -149,6 +150,7 @@ defmodule FaktoryWorker.Job do
 
   @doc false
   def push(_, invalid_payload = {:error, _}), do: invalid_payload
+
   def push(faktory_name, job) do
     faktory_name
     |> Pool.format_pool_name()
@@ -202,6 +204,12 @@ defmodule FaktoryWorker.Job do
     Telemetry.execute(:push, :ok, job)
 
     {:ok, job}
+  end
+
+  defp handle_push_result({:error, :timeout}, job) do
+    Telemetry.execute(:push, {:error, :timeout}, job)
+
+    {:error, :timeout}
   end
 
   defp handle_push_result({:error, reason}, _) do

--- a/lib/faktory_worker/telemetry.ex
+++ b/lib/faktory_worker/telemetry.ex
@@ -38,6 +38,10 @@ defmodule FaktoryWorker.Telemetry do
     log_info("NOTUNIQUE", job.jid, job.args, job.jobtype)
   end
 
+  defp log_event(:push, %{status: {:error, :timeout}}, job) do
+    log_info("Push Timeout", job.jid, job.args, job.jobtype)
+  end
+
   # Beat events
 
   # no state change, status == status

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule FaktoryWorker.MixProject do
   def project do
     [
       app: :faktory_worker,
-      version: "1.8.0",
+      version: "1.8.1",
       elixir: "~> 1.8",
       description: description(),
       package: package(),


### PR DESCRIPTION
Push timeouts should be rare in practice, usually occurring only when the connection pool is saturated by a large number of jobs being created at once. This PR adds a `try/catch` wrapper for job pushes, so that timeouts will be converted into an `{:error, :timeout}` return instead of raising. They'll also generate a `:push` telemetry event, allowing client code to listen for and record metrics around failed pushes.