### PR TITLE
include `docs/mutate.md` in hex documentation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,8 @@ defmodule FaktoryWorker.MixProject do
       "README.md": [filename: "faktory-worker"],
       "docs/configuration.md": [title: "Configuration"],
       "docs/logging.md": [title: "Logging"],
-      "docs/sandbox-testing.md": [title: "Sandbox Testing"]
+      "docs/sandbox-testing.md": [title: "Sandbox Testing"],
+      "docs/mutate.md": [title: "Mutate API"]
     ]
   end
 


### PR DESCRIPTION
I forgot to include this with #158. No rush on deploying this now, just wanted to have it in place for whenever the next release is cut.