### PR TITLE
add `FaktoryWorker.send_command/2`, support enterprise tracking

### DIFF
--- a/docs/mutate.md
+++ b/docs/mutate.md
@@ -17,20 +17,13 @@ this may be enhanced with a first-class Elixir API, but for now calls must be
 made manually:
 
 ```elixir
-alias FaktoryWorker.Pool
-alias FaktoryWorker.ConnectionManager.Server
-
-pool = FaktoryWorker # or whichever custom pool you want to use
-conn = Pool.format_pool_name(pool)
-timeout = 5_000
-
 args = %{
   cmd: "kill",
   target: "default",
   filter: %{jobtype: "MyApp.Job"}
 }
 
-:poolboy.transaction(&Server.send_command(&1, {:mutate, args}), timeout)
+FaktoryWorker.send_command({:mutate, args})
 ```
 
 See [here](https://github.com/contribsys/faktory/wiki/Mutate-API#mutate) for the

--- a/lib/faktory_worker.ex
+++ b/lib/faktory_worker.ex
@@ -24,6 +24,10 @@ defmodule FaktoryWorker do
   For a full list of configuration options see the [Configuration](configuration.html) documentation.
   """
 
+  alias FaktoryWorker.{ConnectionManager, Pool}
+
+  @default_timeout 5_000
+
   @doc false
   def child_spec(opts \\ []) do
     opts = Keyword.put_new(opts, :name, __MODULE__)
@@ -61,5 +65,37 @@ defmodule FaktoryWorker do
   @spec attach_default_telemetry_handler :: :ok | {:error, :already_exists}
   def attach_default_telemetry_handler() do
     FaktoryWorker.Telemetry.attach_default_handler()
+  end
+
+  @type command :: FaktoryWorker.Protocol.protocol_command()
+
+  @type send_command_opt :: {:faktory_name, module()} | {:timeout, pos_integer()}
+
+  @doc """
+  Send a command to the Faktory server.
+
+  In most cases, `FaktoryWorker` handles sending commands on your behalf.
+  However, there are some APIs (such as Enterprise Batches and Tracking)
+  where it's useful to send a command directly.
+
+  The full list of supported commands is available in
+  `FaktoryWorker.Protocol.protocol_command()`. It is left to the caller to
+  verify that command arguments are valid.
+
+  ## Options
+
+  - `faktory_name` the Faktory instance to use (default: #{inspect(__MODULE__)})
+  - `timeout` how long to wait for a response, in ms (default: #{@default_timeout})
+
+  """
+  @spec send_command(command(), [send_command_opt()]) :: FaktoryWorker.Connection.response()
+  def send_command(command, opts \\ []) do
+    opts
+    |> Keyword.get(:faktory_name, __MODULE__)
+    |> Pool.format_pool_name()
+    |> :poolboy.transaction(
+      &ConnectionManager.Server.send_command(&1, command),
+      Keyword.get(opts, :timeout, @default_timeout)
+    )
   end
 end

--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -85,7 +85,7 @@ defmodule FaktoryWorker.Job do
   means only values that implement the `Jason.Encoder` protocol are valid when calling the `perform_async/2` function.
   """
 
-  alias FaktoryWorker.{ConnectionManager, Random, Pool, Telemetry, Sandbox}
+  alias FaktoryWorker.{Random, Telemetry, Sandbox}
 
   # Look at supporting the following optional fields when pushing a job
   # priority
@@ -152,12 +152,8 @@ defmodule FaktoryWorker.Job do
   def push(_, invalid_payload = {:error, _}), do: invalid_payload
 
   def push(faktory_name, job) do
-    faktory_name
-    |> Pool.format_pool_name()
-    |> :poolboy.transaction(
-      &ConnectionManager.Server.send_command(&1, {:push, job}),
-      @default_push_timeout
-    )
+    {:push, job}
+    |> FaktoryWorker.send_command(faktory_name: faktory_name, timeout: @default_push_timeout)
     |> handle_push_result(job)
   end
 

--- a/lib/faktory_worker/protocol.ex
+++ b/lib/faktory_worker/protocol.ex
@@ -12,6 +12,9 @@ defmodule FaktoryWorker.Protocol do
           | {:fetch, queues :: [String.t()]}
           | {:ack, job_id :: String.t()}
           | {:fail, args :: map()}
+          | {:mutate, args :: map()}
+          | {:track_get, job_id :: String.t()}
+          | {:track_set, args :: map()}
           | :info
           | :end
           | :flush
@@ -72,6 +75,14 @@ defmodule FaktoryWorker.Protocol do
     encode("MUTATE", args)
   end
 
+  def encode_command({:track_get, job_id}) do
+    encode("TRACK GET", job_id)
+  end
+
+  def encode_command({:track_set, args}) do
+    encode("TRACK SET", args)
+  end
+
   def encode_command(:info) do
     encode("INFO")
   end
@@ -82,6 +93,10 @@ defmodule FaktoryWorker.Protocol do
 
   def encode_command(:flush) do
     encode("FLUSH")
+  end
+
+  def encode_command(command) do
+    raise "invalid command: unable to encode `#{inspect(command)}`"
   end
 
   @spec decode_response(response :: String.t()) :: protocol_response()


### PR DESCRIPTION
A recent PR #158 added support for the `MUTATE` command, but calling it was pretty hefty:

```elixir
alias FaktoryWorker.Pool
alias FaktoryWorker.ConnectionManager.Server

pool = FaktoryWorker # or whichever custom pool you want to use
conn = Pool.format_pool_name(pool)
timeout = 5_000

args = %{
  cmd: "kill",
  target: "default",
  filter: %{jobtype: "MyApp.Job"}
}

:poolboy.transaction(&Server.send_command(&1, {:mutate, args}), timeout)
```

This PR wraps the logic for sending a command (which was already used in a couple other places) into a helper function `FaktoryWorker.send_command/2`, which allows that earlier example to be simplified to just:

```elixir
args = %{
  cmd: "kill",
  target: "default",
  filter: %{jobtype: "MyApp.Job"}
}

FaktoryWorker.send_command({:mutate, args})
```

Additionally, this PR also adds support for the `TRACK GET` and `TRACK SET` APIs used by [Ent Tracking](https://github.com/contribsys/faktory/wiki/Ent-Tracking).