### PR TITLE
Add warn/error level logging in telemetry to appropriate events

### DIFF
--- a/lib/faktory_worker/telemetry.ex
+++ b/lib/faktory_worker/telemetry.ex
@@ -35,7 +35,7 @@ defmodule FaktoryWorker.Telemetry do
   end
 
   defp log_event(:push, %{status: {:error, :not_unique}}, job) do
-    log_info("NOTUNIQUE", job.jid, job.args, job.jobtype)
+    log_warn("NOTUNIQUE", job.jid, job.args, job.jobtype)
   end
 
   # Beat events
@@ -50,7 +50,7 @@ defmodule FaktoryWorker.Telemetry do
   end
 
   defp log_event(:beat, %{status: :error}, %{wid: wid}) do
-    log_info("Heartbeat Failed", wid)
+    log_warn("Heartbeat Failed", wid)
   end
 
   # Fetch events
@@ -66,17 +66,17 @@ defmodule FaktoryWorker.Telemetry do
   end
 
   defp log_event(:ack, %{status: :error}, job) do
-    log_info("Failed", job.jid, job.args, job.jobtype)
+    log_error("Failed", job.jid, job.args, job.jobtype)
   end
 
   # Failed acks
 
   defp log_event(:failed_ack, %{status: :ok}, job) do
-    log_info("Error sending 'ACK' acknowledgement to faktory", job.jid, job.args, job.jobtype)
+    log_warn("Error sending 'ACK' acknowledgement to faktory", job.jid, job.args, job.jobtype)
   end
 
   defp log_event(:failed_ack, %{status: :error}, job) do
-    log_info("Error sending 'FAIL' acknowledgement to faktory", job.jid, job.args, job.jobtype)
+    log_error("Error sending 'FAIL' acknowledgement to faktory", job.jid, job.args, job.jobtype)
   end
 
   # Log formats
@@ -92,4 +92,29 @@ defmodule FaktoryWorker.Telemetry do
   defp log_info(outcome, jid, args, worker_module) do
     log_info("#{outcome} (#{worker_module}) jid-#{jid} #{inspect(args)}")
   end
+
+  def log_warn(message) do
+    Logger.warn("[faktory-worker] #{message}")
+  end
+
+  defp log_warn(outcome, wid) do
+    log_warn("#{outcome} wid-#{wid}")
+  end
+
+  defp log_warn(outcome, jid, args, worker_module) do
+    log_warn("#{outcome} (#{worker_module}) jid-#{jid} #{inspect(args)}")
+  end
+
+  def log_error(message) do
+    Logger.error("[faktory-worker] #{message}")
+  end
+
+  defp log_error(outcome, wid) do
+    log_error("#{outcome} wid-#{wid}")
+  end
+
+  defp log_error(outcome, jid, args, worker_module) do
+    log_error("#{outcome} (#{worker_module}) jid-#{jid} #{inspect(args)}")
+  end
+
 end


### PR DESCRIPTION
This comes in response to some problems we had in production. Ideally,
we should have warning/error level logs for certain events.

This does the following:

- log warn when `NOTUNIQUE`
- log warn on heartbeat failure
- log error on job failure
- log warn on failed `ACK` with `:ok` status
- log error on failed `ACK` with `:error` status

It maintains the same formatting as the `info` level helper already set
up, as to not mess up any saved searches folks may have, but gives this
granularity for easier inspection in situations like mass job-failure.

## Aside
The problems we were seeing this stems from largely hinge around the failure of `ACK`-ing jobs upstream and those log levels being `info` made it a bit harder to dig into things.

As a next step, we may want to consider a means of adding backpressure handling to the sending of all these messages out when trying to put jobs onto the queue. If we kick off a couple thousand, the failures pile up and in one instance for us led to a partial outage. Its reasonable to assume this is possible when flooding the connection, and #157 made it such that we dont raise and cause a ton of noise/failures in parent applications, but we ideally would have a means where if a user is shoving thousands of jobs up to the queue that they would be able to do so without writing preventative code or a band-aid atop this library's API.