### PR TITLE
fix issue when port is left dangling and catch poolboy timeout errors

### DIFF
--- a/lib/faktory_worker/connection.ex
+++ b/lib/faktory_worker/connection.ex
@@ -26,6 +26,11 @@ defmodule FaktoryWorker.Connection do
     end
   end
 
+  @spec close(conn :: __MODULE__.t()) :: :ok
+  def close(%{socket_handler: socket_handler} = conn) do
+    socket_handler.close(conn)
+  end
+
   @spec send_command(connection :: __MODULE__.t(), Protocol.protocol_command()) :: response()
   def send_command(%{socket_handler: socket_handler} = connection, :end) do
     with {:ok, payload} <- Protocol.encode_command(:end),
@@ -74,9 +79,7 @@ defmodule FaktoryWorker.Connection do
 
   defp send_handshake({:ok, %{"v" => version}}, _, _) when version != @faktory_version do
     {:error,
-     "Only Faktory version '#{@faktory_version}' is supported (connected to Faktory version '#{
-       version
-     }')."}
+     "Only Faktory version '#{@faktory_version}' is supported (connected to Faktory version '#{version}')."}
   end
 
   defp send_handshake({:ok, response}, connection, opts) do

--- a/lib/faktory_worker/connection_manager.ex
+++ b/lib/faktory_worker/connection_manager.ex
@@ -33,6 +33,8 @@ defmodule FaktoryWorker.ConnectionManager do
   def send_command(state, command, allow_retry \\ true) do
     case try_send_command(state, command) do
       {{:error, reason}, _} when reason in @connection_errors ->
+        # Close dangling port
+        close_connection(state)
         error = {:error, "Failed to connect to Faktory"}
         state = %{state | conn: nil}
 
@@ -76,6 +78,10 @@ defmodule FaktoryWorker.ConnectionManager do
       {:ok, connection} -> connection
       {:error, _reason} -> nil
     end
+  end
+
+  defp close_connection(%{conn: conn}) do
+    Connection.close(conn)
   end
 
   defp log_error(reason, {_, %{jid: jid}}) do

--- a/lib/faktory_worker/socket.ex
+++ b/lib/faktory_worker/socket.ex
@@ -13,4 +13,6 @@ defmodule FaktoryWorker.Socket do
 
   @callback recv(connection :: Connection.t(), length :: pos_integer()) ::
               {:ok, String.t()} | {:error, term()}
+
+  @callback close(connection :: Connection.t()) :: :ok
 end

--- a/lib/faktory_worker/socket/ssl.ex
+++ b/lib/faktory_worker/socket/ssl.ex
@@ -31,6 +31,11 @@ defmodule FaktoryWorker.Socket.Ssl do
     result
   end
 
+  @impl true
+  def close(%{socket: socket}) do
+    :ssl.close(socket)
+  end
+
   defp try_connect(host, port, opts) do
     host = String.to_charlist(host)
     tls_verify = Keyword.get(opts, :tls_verify, true)

--- a/lib/faktory_worker/socket/tcp.ex
+++ b/lib/faktory_worker/socket/tcp.ex
@@ -31,6 +31,11 @@ defmodule FaktoryWorker.Socket.Tcp do
     result
   end
 
+  @impl true
+  def close(%{socket: socket}) do
+    :gen_tcp.close(socket)
+  end
+
   defp try_connect(host, port) do
     host = String.to_charlist(host)
 

--- a/lib/faktory_worker/telemetry.ex
+++ b/lib/faktory_worker/telemetry.ex
@@ -120,5 +120,4 @@ defmodule FaktoryWorker.Telemetry do
   defp log_error(outcome, jid, args, worker_module) do
     log_error("#{outcome} (#{worker_module}) jid-#{jid} #{inspect(args)}")
   end
-
 end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5900925/198991977-0a069940-7015-4898-a7d0-bde267282488.png)

When we open connection to Faktory, we observe some events but we never take care of port in terms of closing it. 

When we receive one of following signals : ```:closed,
    :enotconn,
    :econnrefused``` we just ignore current socket and open a new one, which leads to port leak.
In this PR we are explicitly closing socket, and after observation `:erlang.ports` it shows that number of ports are not rising any more, everything stays in normal boundaries as it should be.
    
Also, we have `handle_push_result({:error, :timeout}, job)`  but we are not catching timeout properly, because poolboy checkout raises an exception. In this PR we are catching exception and returning `{:error, :timeout}` which should be picked up by `handle_push_result`.