### PR TITLE
feat: include queue/duration in telemetry

### DIFF
--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -197,13 +197,13 @@ defmodule FaktoryWorker.Job do
   end
 
   defp handle_push_result({:ok, _}, job) do
-    Telemetry.execute(:push, :ok, job)
+    Telemetry.execute(:push, :ok, Map.put_new(job, :queue, "default"))
 
     {:ok, job}
   end
 
   defp handle_push_result({:error, :timeout}, job) do
-    Telemetry.execute(:push, {:error, :timeout}, job)
+    Telemetry.execute(:push, {:error, :timeout}, Map.put_new(job, :queue, "default"))
 
     {:error, :timeout}
   end

--- a/lib/faktory_worker/telemetry.ex
+++ b/lib/faktory_worker/telemetry.ex
@@ -41,15 +41,15 @@ defmodule FaktoryWorker.Telemetry do
   # Push events
 
   defp log_event(:push, %{status: :ok}, job) do
-    log(:info, "Enqueued", job.jid, job.args, job.jobtype, job[:queue])
+    log(:info, "Enqueued", job.jid, job.args, job.jobtype, job.queue)
   end
 
   defp log_event(:push, %{status: {:error, :not_unique}}, job) do
-    log(:warn, "NOTUNIQUE", job.jid, job.args, job.jobtype, job[:queue])
+    log(:warn, "NOTUNIQUE", job.jid, job.args, job.jobtype, job.queue)
   end
 
   defp log_event(:push, %{status: {:error, :timeout}}, job) do
-    log(:info, "Push Timeout", job.jid, job.args, job.jobtype, job[:queue])
+    log(:info, "Push Timeout", job.jid, job.args, job.jobtype, job.queue)
   end
 
   # Beat events
@@ -132,7 +132,7 @@ defmodule FaktoryWorker.Telemetry do
     log(level, "#{outcome} wid-#{wid}")
   end
 
-  defp log(level, outcome, jid, args, worker_module, default) when default in ["default", nil] do
+  defp log(level, outcome, jid, args, worker_module, "default") do
     log(level, "#{outcome} (#{worker_module}) jid-#{jid} #{inspect(args)}")
   end
 

--- a/lib/faktory_worker/telemetry.ex
+++ b/lib/faktory_worker/telemetry.ex
@@ -3,7 +3,17 @@ defmodule FaktoryWorker.Telemetry do
 
   require Logger
 
-  @events [:push, :beat, :fetch, :ack, :failed_ack, :job_timeout, :batch_new, :batch_open, :batch_commit]
+  @events [
+    :push,
+    :beat,
+    :fetch,
+    :ack,
+    :failed_ack,
+    :job_timeout,
+    :batch_new,
+    :batch_open,
+    :batch_commit
+  ]
 
   @doc false
   @spec attach_default_handler :: :ok | {:error, :already_exists}
@@ -31,15 +41,15 @@ defmodule FaktoryWorker.Telemetry do
   # Push events
 
   defp log_event(:push, %{status: :ok}, job) do
-    log_info("Enqueued", job.jid, job.args, job.jobtype)
+    log(:info, "Enqueued", job.jid, job.args, job.jobtype, job[:queue])
   end
 
   defp log_event(:push, %{status: {:error, :not_unique}}, job) do
-    log_warn("NOTUNIQUE", job.jid, job.args, job.jobtype)
+    log(:warn, "NOTUNIQUE", job.jid, job.args, job.jobtype, job[:queue])
   end
 
   defp log_event(:push, %{status: {:error, :timeout}}, job) do
-    log_info("Push Timeout", job.jid, job.args, job.jobtype)
+    log(:info, "Push Timeout", job.jid, job.args, job.jobtype, job[:queue])
   end
 
   # Beat events
@@ -50,76 +60,100 @@ defmodule FaktoryWorker.Telemetry do
   end
 
   defp log_event(:beat, %{status: :ok}, %{wid: wid}) do
-    log_info("Heartbeat Succeeded", wid)
+    log(:info, "Heartbeat Succeeded", wid)
   end
 
   defp log_event(:beat, %{status: :error}, %{wid: wid}) do
-    log_warn("Heartbeat Failed", wid)
+    log(:warn, "Heartbeat Failed", wid)
   end
 
   # Fetch events
 
   defp log_event(:fetch, %{status: {:error, reason}}, %{wid: wid}) do
-    log_info("Failed to fetch job due to '#{reason}'", wid)
+    log(:info, "Failed to fetch job due to '#{reason}'", wid)
   end
 
   # Acks
 
   defp log_event(:ack, %{status: :ok}, job) do
-    log_info("Succeeded", job.jid, job.args, job.jobtype)
+    duration = format_duration(job.duration)
+    log(:info, "Succeeded after #{duration}", job.jid, job.args, job.jobtype, job.queue)
   end
 
   defp log_event(:ack, %{status: :error}, job) do
-    log_error("Failed", job.jid, job.args, job.jobtype)
+    duration = format_duration(job.duration)
+    log(:error, "Failed after #{duration}", job.jid, job.args, job.jobtype, job.queue)
   end
 
   # Failed acks
 
   defp log_event(:failed_ack, %{status: :ok}, job) do
-    log_warn("Error sending 'ACK' acknowledgement to faktory", job.jid, job.args, job.jobtype)
+    log(
+      :warn,
+      "Error sending 'ACK' acknowledgement to faktory",
+      job.jid,
+      job.args,
+      job.jobtype,
+      job.queue
+    )
   end
 
   defp log_event(:failed_ack, %{status: :error}, job) do
-    log_error("Error sending 'FAIL' acknowledgement to faktory", job.jid, job.args, job.jobtype)
+    log(
+      :error,
+      "Error sending 'FAIL' acknowledgement to faktory",
+      job.jid,
+      job.args,
+      job.jobtype,
+      job.queue
+    )
   end
 
   # Misc events
 
   defp log_event(:job_timeout, _, job) do
-    log_error("Job has reached its reservation timeout and will be failed", job.jid, job.args, job.jobtype)
+    log(
+      :error,
+      "Job has reached its reservation timeout and will be failed",
+      job.jid,
+      job.args,
+      job.jobtype,
+      job.queue
+    )
   end
 
   # Log formats
 
-  defp log_info(message) do
-    Logger.info("[faktory-worker] #{message}")
+  defp log(:info, message), do: Logger.info("[faktory-worker] #{message}")
+  defp log(:warn, message), do: Logger.warning("[faktory-worker] #{message}")
+  defp log(:error, message), do: Logger.error("[faktory-worker] #{message}")
+
+  defp log(level, outcome, wid) do
+    log(level, "#{outcome} wid-#{wid}")
   end
 
-  defp log_info(outcome, wid) do
-    log_info("#{outcome} wid-#{wid}")
+  defp log(level, outcome, jid, args, worker_module, default) when default in ["default", nil] do
+    log(level, "#{outcome} (#{worker_module}) jid-#{jid} #{inspect(args)}")
   end
 
-  defp log_info(outcome, jid, args, worker_module) do
-    log_info("#{outcome} (#{worker_module}) jid-#{jid} #{inspect(args)}")
+  defp log(level, outcome, jid, args, worker_module, queue) do
+    log(level, "#{outcome} (#{worker_module}) [#{queue}] jid-#{jid} #{inspect(args)}")
   end
 
-  def log_warn(message) do
-    Logger.warn("[faktory-worker] #{message}")
+  defp format_duration(ms) when ms < 1_000, do: "#{ms}ms"
+  defp format_duration(ms) when ms < 60_000, do: "#{ms / 1_000}s"
+
+  defp format_duration(ms) when ms < 3_600_000 do
+    minutes = ms / 1_000 / 60
+    m = floor(minutes)
+    rest = round((minutes - m) * 60 * 1_000)
+    "#{m}m #{format_duration(rest)}"
   end
 
-  defp log_warn(outcome, wid) do
-    log_warn("#{outcome} wid-#{wid}")
-  end
-
-  defp log_warn(outcome, jid, args, worker_module) do
-    log_warn("#{outcome} (#{worker_module}) jid-#{jid} #{inspect(args)}")
-  end
-
-  def log_error(message) do
-    Logger.error("[faktory-worker] #{message}")
-  end
-
-  defp log_error(outcome, jid, args, worker_module) do
-    log_error("#{outcome} (#{worker_module}) jid-#{jid} #{inspect(args)}")
+  defp format_duration(ms) do
+    hours = ms / 1_000 / 60 / 60
+    h = floor(hours)
+    rest = round((hours - h) * 60 * 60 * 1_000)
+    "#{h}h #{format_duration(rest)}"
   end
 end

--- a/test/faktory_worker/telemetry_test.exs
+++ b/test/faktory_worker/telemetry_test.exs
@@ -61,7 +61,8 @@ defmodule FaktoryWorker.TelemetryTest do
       metadata = %{
         jid: Random.job_id(),
         args: %{hey: "there!"},
-        jobtype: "TestQueueWorker"
+        jobtype: "TestQueueWorker",
+        queue: "default"
       }
 
       log_message =
@@ -79,7 +80,8 @@ defmodule FaktoryWorker.TelemetryTest do
       metadata = %{
         jid: Random.job_id(),
         args: %{hey: "there!"},
-        jobtype: "TestQueueWorker"
+        jobtype: "TestQueueWorker",
+        queue: "default"
       }
 
       log_message =


### PR DESCRIPTION
This PR adds `queue` and `duration` to relevant push/ack telemetry events, allowing improved observability around how long jobs take to complete and allowing telemetry events to be aggregated by queue in addition to job type. Logger messages now also include the queue (when it's anything other than `default`) and job duration in the case of either success or failure.