### PR TITLE
fix: send FAIL ack when worker is terminated

### DIFF
--- a/lib/faktory_worker/worker/server.ex
+++ b/lib/faktory_worker/worker/server.ex
@@ -80,8 +80,11 @@ defmodule FaktoryWorker.Worker.Server do
   end
 
   @impl true
-  def terminate(_, state = %{job_ref: %{ref: job_ref}}) when is_reference(job_ref) do
-    Worker.ack_job(state, {:error, "Worker Terminated"})
+  def terminate(_, state = %{job_ref: task = %Task{}}) do
+    case Task.shutdown(task, :brutal_kill) do
+      {:ok, _} -> Worker.ack_job(state, :ok)
+      _ -> Worker.ack_job(state, {:error, "Worker Terminated"})
+    end
   end
 
   def terminate(_, state) do

--- a/lib/faktory_worker/worker/server.ex
+++ b/lib/faktory_worker/worker/server.ex
@@ -80,6 +80,10 @@ defmodule FaktoryWorker.Worker.Server do
   end
 
   @impl true
+  def terminate(_, state = %{job_ref: %{ref: job_ref}}) when is_reference(job_ref) do
+    Worker.ack_job(state, {:error, "Worker Terminated"})
+  end
+
   def terminate(_, state) do
     Worker.checkin_queues(state)
   end

--- a/test/faktory_worker/worker/server_test.exs
+++ b/test/faktory_worker/worker/server_test.exs
@@ -188,9 +188,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
 
       Process.sleep(100)
 
-      state = :sys.get_state(pid)
-      state = Server.terminate(:shutdown, state)
-      :sys.replace_state(pid, fn _ -> state end)
+      stop_supervised!(:test_worker_1)
     end
   end
 

--- a/test/faktory_worker/worker/server_test.exs
+++ b/test/faktory_worker/worker/server_test.exs
@@ -128,6 +128,70 @@ defmodule FaktoryWorker.Worker.ServerTest do
     test "should successfully terminate when queues is set to nil" do
       assert :ok == Server.terminate(:shutdown, %{faktory_name: FaktoryWorker, queues: nil})
     end
+
+    test "should send 'FAIL' command if a job is currently in progress" do
+      start_supervised!({QueueManager, name: FaktoryWorker, worker_pool: [queues: ["default"]]})
+      start_supervised!({FaktoryWorker.JobSupervisor, name: FaktoryWorker})
+
+      job =
+        Jason.encode!(%{
+          "args" => [%{"hey" => "there!"}],
+          "created_at" => "2019-04-09T12:14:07.6550641Z",
+          "enqueued_at" => "2019-04-09T12:14:07.6550883Z",
+          "jid" => "f47ccc395ef9d9646118434f",
+          "jobtype" => "FaktoryWorker.TimeoutQueueWorker",
+          "queue" => "default"
+        })
+
+      fail_payload =
+        Jason.encode!(%{
+          backtrace: [],
+          errtype: "Undetected Error Type",
+          jid: "f47ccc395ef9d9646118434f",
+          message: "\"Worker Terminated\""
+        })
+
+      fail_command = "FAIL #{fail_payload}\r\n"
+
+      worker_connection_mox()
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, "FETCH default\r\n" ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "$#{byte_size(job)}\r\n"}
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _, _ ->
+        {:ok, "#{job}\r\n"}
+      end)
+
+      expect(FaktoryWorker.SocketMock, :send, fn _, ^fail_command ->
+        :ok
+      end)
+
+      expect(FaktoryWorker.SocketMock, :recv, fn _ ->
+        {:ok, "+OK\r\n"}
+      end)
+
+      opts = [
+        name: :test_worker_1,
+        process_wid: Random.process_wid(),
+        disable_fetch: true,
+        connection: [socket_handler: FaktoryWorker.SocketMock]
+      ]
+
+      pid = start_supervised!(Server.child_spec(opts))
+
+      Process.send(pid, :fetch, [])
+
+      Process.sleep(100)
+
+      state = :sys.get_state(pid)
+      state = Server.terminate(:shutdown, state)
+      :sys.replace_state(pid, fn _ -> state end)
+    end
   end
 
   describe "job timeout" do


### PR DESCRIPTION
Whenever a worker is terminated while running a job (when the application itself is terminated via `SIGTERM`, for example), the job is left in a pending state until `reserve_timeout` is met. The job should instead be ack'd as failed so that another worker can pick it back up, since we know it's never going to complete.

This should fix the issue in continuous deployment environments when a deployment is terminated and replaced by a newer instance where any in-progress jobs are left hanging.