### PR TITLE
Heartbeat can recover from an error condition.

### DIFF
--- a/lib/faktory_worker/connection_manager.ex
+++ b/lib/faktory_worker/connection_manager.ex
@@ -87,6 +87,6 @@ defmodule FaktoryWorker.ConnectionManager do
   defp close_connection(%{conn: nil}), do: :ok
 
   defp log_error(reason, {_, %{jid: jid}}) do
-    Logger.warning("[#{jid}] #{reason}")
+    Logger.warning("[faktory-worker] [#{jid}] #{reason}")
   end
 end

--- a/lib/faktory_worker/worker/hearbeat_server.ex
+++ b/lib/faktory_worker/worker/hearbeat_server.ex
@@ -8,6 +8,8 @@ defmodule FaktoryWorker.Worker.HeartbeatServer do
   alias FaktoryWorker.Worker.Server
   alias FaktoryWorker.Worker.Pool
 
+  require Logger
+
   @spec start_link(opts :: keyword()) :: GenServer.on_start()
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: name_from_opts(opts))
@@ -101,7 +103,9 @@ defmodule FaktoryWorker.Worker.HeartbeatServer do
     %{state | beat_state: new_beat_state, conn: conn, beat_ref: nil}
   end
 
-  defp handle_beat_response({{result, _}, conn}, state) when result in [:ok, :error] do
+  defp handle_beat_response({{result, msg}, conn}, state) when result in [:ok, :error] do
+    Logger.info("[faktory-worker] unexpected heartbeat response #{inspect({result, msg})}")
+
     Telemetry.execute(:beat, result, %{
       prev_status: state.beat_state,
       wid: state.process_wid

--- a/lib/faktory_worker/worker/hearbeat_server.ex
+++ b/lib/faktory_worker/worker/hearbeat_server.ex
@@ -60,7 +60,7 @@ defmodule FaktoryWorker.Worker.HeartbeatServer do
 
   @impl true
   def handle_info(:beat, %{conn: conn, process_wid: process_wid, beat_state: beat_state} = state)
-      when beat_state in [:ok, :quiet] do
+      when beat_state in [:ok, :quiet, :error] do
     state =
       conn
       |> ConnectionManager.send_command({:beat, process_wid})
@@ -70,6 +70,10 @@ defmodule FaktoryWorker.Worker.HeartbeatServer do
   end
 
   def handle_info(:beat, state) do
+    Logger.info(
+      "[faktory-worker] not sending heartbeat because the beat_state is #{inspect(state.beat_state)}"
+    )
+
     {:noreply, %{state | beat_ref: nil}, {:continue, :schedule_beat}}
   end
 

--- a/lib/faktory_worker/worker/hearbeat_server.ex
+++ b/lib/faktory_worker/worker/hearbeat_server.ex
@@ -104,7 +104,8 @@ defmodule FaktoryWorker.Worker.HeartbeatServer do
   end
 
   defp handle_beat_response({{result, msg}, conn}, state) when result in [:ok, :error] do
-    Logger.info("[faktory-worker] unexpected heartbeat response #{inspect({result, msg})}")
+    if result != :ok,
+      do: Logger.info("[faktory-worker] unexpected heartbeat response #{inspect({result, msg})}")
 
     Telemetry.execute(:beat, result, %{
       prev_status: state.beat_state,

--- a/test/faktory_worker/worker_test.exs
+++ b/test/faktory_worker/worker_test.exs
@@ -233,7 +233,17 @@ defmodule FaktoryWorker.WorkerTest do
 
       worker_connection_mox()
 
-      expect(FaktoryWorker.SocketMock, :send, fn _, "FETCH test_queue default\r\n" ->
+      expect(FaktoryWorker.SocketMock, :send, fn _, "FETCH " <> msg ->
+        assert String.ends_with?(msg, "\r\n")
+
+        sorted_queues =
+          msg
+          |> String.trim("\r\n")
+          |> String.split(" ")
+          |> Enum.sort()
+
+        assert sorted_queues == ["default", "test_queue"]
+
         :ok
       end)
 


### PR DESCRIPTION
If the faktory server restarted, and we received an error from an attempted heartbeat, the heartbeat server would stop sending a heartbeat.  This behavior looks like an oversight, the real goal was to continue the heartbeat until the worker was shutdown, or received a terminate request.

To fix, I included the error state in the list of states in which a heartbeat should be sent.

