### PR TITLE
Allow custom connection labels

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,8 @@ Below is the full structure of available options and a definition for each one.
     host: String.t(),
     port: pos_integer(),
     password: String.t(),
-    use_tls: boolean()
+    use_tls: boolean(),
+    labels: list(String.t())
   ],
   pool: [
     size: pos_integer(),
@@ -55,6 +56,7 @@ Below is the full structure of available options and a definition for each one.
   - `port` (default: `7419`) - The tcp port used to connect to Faktory.
   - `password` (default: `nil`) - The password used to authenticate with Faktory.
   - `use_tls` (default: `false`) - A boolean flag that indicates whether Faktory Worker should connect using a TLS connection.
+  - `labels` (default: `["elixir-#{System.version()}"]`) - A list of strings added to the worker processes.
 
 - `pool` - A list of options to configure the pool of Faktory connections used for sending jobs to Faktory.
 

--- a/lib/faktory_worker/connection.ex
+++ b/lib/faktory_worker/connection.ex
@@ -125,7 +125,7 @@ defmodule FaktoryWorker.Connection do
       hostname: to_string(hostname),
       wid: process_wid,
       pid: String.to_integer(sys_pid),
-      labels: ["elixir-#{System.version()}"]
+      labels: Keyword.get(opts, :labels, ["elixir-#{System.version()}"])
     }
 
     Map.merge(args, worker_args)

--- a/test/faktory_worker/connection/connection_test.exs
+++ b/test/faktory_worker/connection/connection_test.exs
@@ -77,6 +77,19 @@ defmodule FaktoryWorker.Connection.ConnectionTest do
       assert {:ok, %Connection{}} = Connection.open(opts)
     end
 
+    test "should be able to set custom worker labels" do
+      worker_connection_mox(labels: ["service-xyz"])
+
+      opts = [
+        is_worker: true,
+        labels: ["service-xyz"],
+        process_wid: Random.process_wid(),
+        socket_handler: FaktoryWorker.SocketMock
+      ]
+
+      assert {:ok, %Connection{}} = Connection.open(opts)
+    end
+
     test "should return an error if the returned faktory version is not supported" do
       opts = [socket_handler: FaktoryWorker.SocketMock]
 

--- a/test/support/connection_helpers.ex
+++ b/test/support/connection_helpers.ex
@@ -27,8 +27,8 @@ defmodule FaktoryWorker.ConnectionHelpers do
     end
   end
 
-  defmacro worker_connection_mox() do
-    quote do
+  defmacro worker_connection_mox(opts \\ []) do
+    quote bind_quoted: [opts: opts] do
       {:ok, expected_host} = :inet.gethostname()
       expected_sys_pid = System.pid()
       runtime_vsn = System.version()
@@ -55,7 +55,7 @@ defmodule FaktoryWorker.ConnectionHelpers do
 
         assert args["hostname"] == to_string(expected_host)
         assert args["pid"] == String.to_integer(expected_sys_pid)
-        assert args["labels"] == ["elixir-#{runtime_vsn}"]
+        assert args["labels"] == Keyword.get(opts, :labels, ["elixir-#{runtime_vsn}"])
         assert String.length(args["wid"]) == 16
         assert args["v"] == 2
 


### PR DESCRIPTION
Adds the possibility to configure custom labels to be added to the worker processes.

This can be done by adding `labels` keys to the connection config

```elixir
def start(_, _) do
  children = [
    {FaktoryWorker, connection: [
      host: "localhost",
      password: "very-secret",
      labels: ["dev-machine", "elixir-#{System.version()}"]
    ]}
  ]

  Supervisor.start_link(children,
    strategy: :one_for_one,
    name: FaktoryWorkerUsage.Supervisor
  )
end
```

Resulting in the additional `dev-machine` label being displayed on the faktory worker dashboard 

<img width="1005" alt="Screenshot 2024-05-25 at 17 23 48" src="https://github.com/opt-elixir/faktory_worker/assets/222101/a62ed632-bd41-4d9f-974d-789eeb49b9d5">

closes #191 