### PR TITLE
feat: add `:retry_on_error` config option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ Below is the full structure of available options and a definition for each one.
 ```elixir
 [
   name: atom(),
+  retry_on_error: boolean(),
   connection: [
     host: String.t(),
     port: pos_integer(),
@@ -48,6 +49,8 @@ Below is the full structure of available options and a definition for each one.
 ### Option Definitions
 
 - `name` (default: `FaktoryWorker`) - The name to use for this instance. This is useful if you want to run more than one instance of Faktory Worker. When using this make sure the workers are configured to use the correct instance (see [Worker Configuration](#worker-configuration) below).
+
+- `retry_on_error` (default: `false`) - When disabled, only consider jobs that `raise` as failed and retry them. When enabled, also consider the return value from `perform` callbacks when determining whether or not to retry a job. A return of `:error` or `{:error, term()}` will retry the job.
 
 - `connection` - A list of options to configure the connection to Faktory.
 

--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -69,17 +69,17 @@ defmodule FaktoryWorker.Job do
   ```
   
   If you would like to consider the return value from `perform` and retry when an error is returned, you may enable
-  the `:retry_on_errors` config option.
+  the `:retry_on_error` config option.
   
   ```elixir
   # config.exs
-  config :faktory_worker, retry_on_errors: true
+  config :my_app, FaktoryWorker, retry_on_error: true
   
   # job.ex
   def perform do
     case MyWorker.do_work() do
-      # when `retry_on_errors` is enabled, returning `:error` or `{:error, term()}`
-      # will retry the job
+      # returning `:error` or `{:error, term()}` will retry the job
+      # when `:retry_on_error` is set to `true`
       :error -> :error
       {:error, reason} -> {:error, reason}
       

--- a/lib/faktory_worker/worker.ex
+++ b/lib/faktory_worker/worker.ex
@@ -18,6 +18,7 @@ defmodule FaktoryWorker.Worker do
   defstruct [
     :conn_pid,
     :disable_fetch,
+    :retry_on_error,
     :fetch_ref,
     :process_wid,
     :worker_state,
@@ -40,6 +41,7 @@ defmodule FaktoryWorker.Worker do
     process_wid = Keyword.fetch!(opts, :process_wid)
     retry_interval = Keyword.get(opts, :retry_interval, @five_seconds)
     disable_fetch = Keyword.get(opts, :disable_fetch)
+    retry_on_error = Keyword.get(opts, :retry_on_error)
 
     # Delay connection startup to stagger worker connections. Without this
     # all workers try to connect at the same time and it can't handle the load
@@ -56,6 +58,7 @@ defmodule FaktoryWorker.Worker do
     %__MODULE__{
       conn_pid: conn_pid,
       disable_fetch: disable_fetch,
+      retry_on_error: retry_on_error,
       process_wid: process_wid,
       worker_state: :ok,
       faktory_name: faktory_name,

--- a/lib/faktory_worker/worker/pool.ex
+++ b/lib/faktory_worker/worker/pool.ex
@@ -23,13 +23,15 @@ defmodule FaktoryWorker.Worker.Pool do
     process_wid = Keyword.get(opts, :process_wid)
     pool_opts = Keyword.get(opts, :worker_pool, [])
     disable_fetch = Keyword.get(pool_opts, :disable_fetch, false)
+    retry_on_error = Keyword.get(opts, :retry_on_error, false)
 
     opts = [
       name: :"worker_#{process_wid}_#{number}",
       faktory_name: Keyword.get(opts, :name),
       connection: connection_opts,
       process_wid: process_wid,
-      disable_fetch: disable_fetch
+      disable_fetch: disable_fetch,
+      retry_on_error: retry_on_error
     ]
 
     FaktoryWorker.Worker.Server.child_spec(opts)

--- a/test/faktory_worker/worker/server_integration_test.exs
+++ b/test/faktory_worker/worker/server_integration_test.exs
@@ -14,7 +14,8 @@ defmodule FaktoryWorker.Worker.ServerIntegrationTest do
       opts = [
         name: :test_worker_1,
         process_wid: Random.process_wid(),
-        disable_fetch: true
+        disable_fetch: true,
+        retry_on_error: false
       ]
 
       pid = start_supervised!(Server.child_spec(opts))


### PR DESCRIPTION
This option will allow users to opt-in to a new behaviour, where the job's return value will be considered when determing whether to retry the job. Previously, only a `raise` would constitute a retry-able failure. With this new behaviour enabled, returning `:error` or `{:error, term()}` will also trigger a retry.

This PR also updates the docs to make this behaviour more explicit.