### PR TITLE
Include job failure reason in ack telemetry metadata

### DIFF
--- a/lib/faktory_worker/job.ex
+++ b/lib/faktory_worker/job.ex
@@ -56,25 +56,25 @@ defmodule FaktoryWorker.Job do
 
   When defining `perform` functions, they must always accept one argument for each item in the list of values passed into
   `perform_async/2`.
-  
+
   ## Retrying jobs on failure
 
   When a job fails, the Faktory server can enqueue it again to be retried. By default, a job is only considered
   to have failed when it `raise`s an exception.
-  
+
   ```elixir
   def perform do
     raise "retry me!"
   end
   ```
-  
+
   If you would like to consider the return value from `perform` and retry when an error is returned, you may enable
   the `:retry_on_error` config option.
-  
+
   ```elixir
   # config.exs
   config :my_app, FaktoryWorker, retry_on_error: true
-  
+
   # job.ex
   def perform do
     case MyWorker.do_work() do

--- a/lib/faktory_worker/telemetry.ex
+++ b/lib/faktory_worker/telemetry.ex
@@ -82,7 +82,15 @@ defmodule FaktoryWorker.Telemetry do
 
   defp log_event(:ack, %{status: :error}, job) do
     duration = format_duration(job.duration)
-    log(:error, "Failed after #{duration}", job.jid, job.args, job.jobtype, job.queue)
+
+    log(
+      :error,
+      "Failed after #{duration} due to #{inspect(job.reason)}",
+      job.jid,
+      job.args,
+      job.jobtype,
+      job.queue
+    )
   end
 
   # Failed acks

--- a/lib/faktory_worker/worker.ex
+++ b/lib/faktory_worker/worker.ex
@@ -110,7 +110,7 @@ defmodule FaktoryWorker.Worker do
 
     state.conn_pid
     |> send_command({:ack, state.job_id})
-    |> handle_ack_response(:ok, state)
+    |> handle_ack_response(:ok, nil, state)
   end
 
   def ack_job(state, {:error, reason}) do
@@ -129,7 +129,7 @@ defmodule FaktoryWorker.Worker do
 
     state.conn_pid
     |> send_command({:fail, payload})
-    |> handle_ack_response(:error, state)
+    |> handle_ack_response(:error, reason, state)
   end
 
   def handle_fetch_response({:ok, job}, state) when is_map(job) do
@@ -190,12 +190,13 @@ defmodule FaktoryWorker.Worker do
     state
   end
 
-  defp handle_ack_response({:ok, _}, ack_type, state) do
+  defp handle_ack_response({:ok, _}, ack_type, reason, state) do
     Telemetry.execute(:ack, ack_type, %{
       jid: state.job_id,
       args: state.job["args"],
       jobtype: state.job["jobtype"],
       queue: state.job["queue"],
+      reason: reason,
       duration: System.monotonic_time(:millisecond) - state.job_start
     })
 
@@ -213,12 +214,13 @@ defmodule FaktoryWorker.Worker do
     })
   end
 
-  defp handle_ack_response({:error, _}, ack_type, state) do
+  defp handle_ack_response({:error, _}, ack_type, reason, state) do
     Telemetry.execute(:failed_ack, ack_type, %{
       jid: state.job_id,
       args: state.job["args"],
       jobtype: state.job["jobtype"],
       queue: state.job["queue"],
+      reason: reason,
       duration: System.monotonic_time(:millisecond) - state.job_start
     })
 

--- a/lib/faktory_worker/worker/server.ex
+++ b/lib/faktory_worker/worker/server.ex
@@ -67,7 +67,7 @@ defmodule FaktoryWorker.Worker.Server do
         {true, {:error, reason}} -> {:error, reason}
         _ -> :ok
       end
-    
+
     state = Worker.ack_job(state, ack)
     {:noreply, state}
   end

--- a/test/faktory_worker/worker/server_test.exs
+++ b/test/faktory_worker/worker/server_test.exs
@@ -306,7 +306,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
 
       :ok = stop_supervised(:test_worker_1)
     end
-    
+
     test "should send 'FAIL' command when job returns error" do
       expect_failure = fn result, message ->
         job_id = "f47ccc395ef9d9646118434f"
@@ -354,7 +354,7 @@ defmodule FaktoryWorker.Worker.ServerTest do
 
         :ok = stop_supervised(:test_worker_1)
       end
-      
+
       expect_failure.({:error, "oopsie!"}, "oopsie!")
       expect_failure.(:error, "job returned :error")
     end

--- a/test/faktory_worker/worker_test.exs
+++ b/test/faktory_worker/worker_test.exs
@@ -757,6 +757,7 @@ defmodule FaktoryWorker.WorkerTest do
                args: [%{"hey" => "there!"}],
                jobtype: "FaktoryWorker.TestQueueWorker",
                queue: "test_queue",
+               reason: ^error,
                duration: _
              } = metadata
 


### PR DESCRIPTION
The failure reason passed to `ack_job/2` was used only to build the Faktory FAIL payload and then discarded, so the `:ack` telemetry event and its log line gave no indication of why a job failed.

Thread the reason through handle_ack_response/4 and include it in the :ack and :failed_ack telemetry metadata. The default telemetry handler now prints the reason on the "Failed after ..." log line via inspect/1.

- `worker.ex`: add reason argument to `handle_ack_response`, forwarding the actual reason for failures and nil for successful acks.
- `telemetry.ex`: print the reason in the `:ack` error log event.
- `worker_test.exs`: assert the reason is present in the `:ack` failure metadata.